### PR TITLE
Add SHA3 hashing JSON transformer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,6 +60,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -96,6 +102,7 @@ checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 name = "pipefog"
 version = "0.1.0"
 dependencies = [
+ "hex",
  "lazy_static",
  "regex",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,11 @@
-
 [package]
 name = "pipefog"
 version = "0.1.0"
 edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 sha3 = "0.10.*"
 serde_json = "1.*"
 regex = "*"
 lazy_static = "1.*"
+hex = "0.4"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
-![image](https://github.com/user-attachments/assets/3cf550d5-3656-48b9-9a14-4fb893e80db7)
-
 # pipefog
-Stream-structured obfuscation for JSON/YAML
+
+This tool reads JSON values from standard input and writes them back with every string value replaced by its SHA3-256 hash. Input may consist of multiple JSON documents concatenated together. Each document is printed on a separate line using pretty formatting.
+
+## Usage
+
+```bash
+cat input.json | cargo run --release
+```

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,75 @@
+use sha3::{Digest, Sha3_256};
+use serde_json::{Deserializer, Value};
+use std::io::{self, Write};
+
+fn hash_strings(value: &mut Value) {
+    match value {
+        Value::String(s) => {
+            let mut hasher = Sha3_256::new();
+            hasher.update(s.as_bytes());
+            let result = hasher.finalize();
+            *s = hex::encode(result);
+        }
+        Value::Array(arr) => {
+            for v in arr.iter_mut() {
+                hash_strings(v);
+            }
+        }
+        Value::Object(map) => {
+            for (_, v) in map.iter_mut() {
+                hash_strings(v);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn main() {
+    let stdin = io::stdin();
+    let reader = stdin.lock();
+    let stream = Deserializer::from_reader(reader).into_iter::<Value>();
+    let stdout = io::stdout();
+    let handle = stdout.lock();
+    let mut writer = io::BufWriter::new(handle);
+
+    for value in stream {
+        match value {
+            Ok(mut val) => {
+                hash_strings(&mut val);
+                serde_json::to_writer_pretty(&mut writer, &val).expect("write json");
+                writer.write_all(b"\n").expect("newline");
+            }
+            Err(e) => {
+                eprintln!("Error parsing JSON: {}", e);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn sha3_hex(input: &str) -> String {
+        let mut hasher = Sha3_256::new();
+        hasher.update(input.as_bytes());
+        hex::encode(hasher.finalize())
+    }
+
+    #[test]
+    fn test_hash_strings_simple() {
+        let mut value = json!({
+            "a": "test",
+            "b": ["x", 1],
+            "c": {"d": "y"}
+        });
+
+        hash_strings(&mut value);
+
+        assert_eq!(value["a"], json!(sha3_hex("test")));
+        assert_eq!(value["b"][0], json!(sha3_hex("x")));
+        assert_eq!(value["b"][1], json!(1));
+        assert_eq!(value["c"]["d"], json!(sha3_hex("y")));
+    }
+}


### PR DESCRIPTION
## Summary
- implement a simple JSON stream transformer
- hash string values with SHA3-256 and pretty-print
- document usage in README
- add `hex` crate dependency
- add unit test for hashing

## Testing
- `cargo build --quiet`
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_687a2482e47483309d70eeb2d1d7fc7b