### PR TITLE
Add uppercase word classifier

### DIFF
--- a/src/classifiers.rs
+++ b/src/classifiers.rs
@@ -1,0 +1,53 @@
+use sha3::{Digest, Sha3_256};
+
+/// Detects whether the provided string is composed entirely of ASCII uppercase
+/// letters.
+///
+/// The function takes an `Option<&str>` rather than `&str` to align with the
+/// repository's classifier conventions. If the input matches, the original
+/// string is returned inside `Some`.
+pub fn is_uppercase_word(value: Option<&str>) -> Option<&str> {
+    value.filter(|s| !s.is_empty() && s.chars().all(|c| c.is_ascii_uppercase()))
+}
+
+/// Obfuscate an uppercase word into another deterministic uppercase word of the same length.
+/// The output will also be recognised by `is_uppercase_word`.
+pub fn obfuscate_uppercase_word(word: &str) -> String {
+    let mut hasher = Sha3_256::new();
+    hasher.update(word.as_bytes());
+    let hash = hasher.finalize();
+    let mut out = String::with_capacity(word.len());
+    while out.len() < word.len() {
+        for &b in hash.as_slice() {
+            let c = ((b % 26) as u8 + b'A') as char;
+            out.push(c);
+            if out.len() >= word.len() {
+                break;
+            }
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_uppercase_word_examples() {
+        assert!(is_uppercase_word(Some("UPPERCASE")).is_some());
+        assert!(is_uppercase_word(Some("UPPER_CASE")).is_none());
+        assert!(is_uppercase_word(Some("UPPER CASE")).is_none());
+        assert!(is_uppercase_word(Some("UPPER-CASE")).is_none());
+        assert!(is_uppercase_word(Some("UPPERCASe")).is_none());
+        assert!(is_uppercase_word(None).is_none());
+    }
+
+    #[test]
+    fn test_obfuscate_uppercase_word_preserves_class() {
+        let word = "SECRET";
+        let obf = obfuscate_uppercase_word(word);
+        assert_eq!(obf.len(), word.len());
+        assert!(is_uppercase_word(Some(&obf)).is_some());
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,9 @@ use serde_json::{Deserializer, Value};
 use sha3::{Digest, Sha3_256};
 use std::io::{self, Write};
 
+mod classifiers;
+use classifiers::{is_uppercase_word, obfuscate_uppercase_word};
+
 const SYLLABLES: &[&str] = &[
     "a", "e", "i", "o", "u", "y", "ab", "ac", "ad", "af", "ag", "ah", "ak", "al", "am", "an", "ap",
     "aq", "ar", "as", "at", "av", "aw", "ax", "az", "ba", "be", "bi", "bo", "bu", "by", "ca", "ce",
@@ -59,6 +62,8 @@ fn hash_strings(value: &mut Value) {
         Value::String(s) => {
             if is_alpha_word(s) {
                 *s = hash_word_to_syllables(s);
+            } else if is_uppercase_word(Some(s)).is_some() {
+                *s = obfuscate_uppercase_word(s);
             } else {
                 let mut hasher = Sha3_256::new();
                 hasher.update(s.as_bytes());
@@ -144,7 +149,8 @@ mod tests {
         let mut value = json!({
             "a": "test",
             "b": ["x", 1],
-            "c": {"d": "y"}
+            "c": {"d": "y"},
+            "u": "UPPER"
         });
 
         hash_strings(&mut value);
@@ -153,6 +159,7 @@ mod tests {
         assert_eq!(value["b"][0], json!("o"));
         assert_eq!(value["b"][1], json!(1));
         assert_eq!(value["c"]["d"], json!("u"));
+        assert_eq!(value["u"], json!("XQEAM"));
     }
 
     #[test]
@@ -186,7 +193,7 @@ mod tests {
         const EXPECTED_HASHES: &str = r#"[
   {
     "additional_information": "4e9be9f98ffaf00dfa6849b118ec0eebaeb9d1fedf49794efc978549d692a644",
-    "category": "137e3c8495f71ca7e1c165fd3873705cde985f43c13c516a471840f98d472cc6",
+    "category": "TWICT",
     "created_at": "cf8cbca8ef96e021217ba62b3f9bc79b3358df6ffabf3036555eb093b6a03900",
     "id": "88cf7ddaff83bfd6f3c9b2f8dfd90987628b01a689b04b0d6f4d6bc05e77c8db",
     "last_edited_by": "972e64ff2f45cb894fd548bbdd0f7d430ba23400502ac9c650d4aa053360ca37",


### PR DESCRIPTION
## Summary
- add `classifiers` module with `is_uppercase_word` and deterministic obfuscation
- handle uppercase words when hashing JSON
- update tests for new classifier output
- clarify why `is_uppercase_word` accepts `Option<&str>`

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_687b33d6d0608330b59a301051ecbea8