### PR TITLE
Refactor lowercase classifier and tests

### DIFF
--- a/src/classifiers.rs
+++ b/src/classifiers.rs
@@ -1,17 +1,34 @@
 use sha3::{Digest, Sha3_256};
 
+/// Detects whether the provided string is composed entirely of ASCII lowercase
+/// letters.
+///
+/// This follows the repository's classifier conventions by using the `try_`
+/// prefix and returning an `Option` containing the original string on success.
+pub fn try_alpha_word(input: &str) -> Option<&str> {
+    if !input.is_empty() && input.chars().all(|c| c.is_ascii_lowercase()) {
+        Some(input)
+    } else {
+        None
+    }
+}
+
 /// Detects whether the provided string is composed entirely of ASCII uppercase
 /// letters.
 ///
-/// The function takes an `Option<&str>` rather than `&str` to align with the
-/// repository's classifier conventions. If the input matches, the original
-/// string is returned inside `Some`.
-pub fn is_uppercase_word(value: Option<&str>) -> Option<&str> {
-    value.filter(|s| !s.is_empty() && s.chars().all(|c| c.is_ascii_uppercase()))
+/// The function follows the repository's classifier conventions by using the
+/// `try_` prefix and returning an `Option` containing the original string on
+/// success.
+pub fn try_uppercase_word(input: &str) -> Option<&str> {
+    if !input.is_empty() && input.chars().all(|c| c.is_ascii_uppercase()) {
+        Some(input)
+    } else {
+        None
+    }
 }
 
-/// Obfuscate an uppercase word into another deterministic uppercase word of the same length.
-/// The output will also be recognised by `is_uppercase_word`.
+/// Obfuscate an uppercase word into another deterministic uppercase word of the
+/// same length. The output will also be recognised by `try_uppercase_word`.
 pub fn obfuscate_uppercase_word(word: &str) -> String {
     let mut hasher = Sha3_256::new();
     hasher.update(word.as_bytes());
@@ -34,13 +51,21 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_is_uppercase_word_examples() {
-        assert!(is_uppercase_word(Some("UPPERCASE")).is_some());
-        assert!(is_uppercase_word(Some("UPPER_CASE")).is_none());
-        assert!(is_uppercase_word(Some("UPPER CASE")).is_none());
-        assert!(is_uppercase_word(Some("UPPER-CASE")).is_none());
-        assert!(is_uppercase_word(Some("UPPERCASe")).is_none());
-        assert!(is_uppercase_word(None).is_none());
+    fn test_try_alpha_word_examples() {
+        assert!(try_alpha_word("lowercase").is_some());
+        assert!(try_alpha_word("lower_case").is_none());
+        assert!(try_alpha_word("Lowercase").is_none());
+        assert!(try_alpha_word("lower-case").is_none());
+        assert!(try_alpha_word("LOWERCASE").is_none());
+    }
+
+    #[test]
+    fn test_try_uppercase_word_examples() {
+        assert!(try_uppercase_word("UPPERCASE").is_some());
+        assert!(try_uppercase_word("UPPER_CASE").is_none());
+        assert!(try_uppercase_word("UPPER CASE").is_none());
+        assert!(try_uppercase_word("UPPER-CASE").is_none());
+        assert!(try_uppercase_word("UPPERCASe").is_none());
     }
 
     #[test]
@@ -48,6 +73,6 @@ mod tests {
         let word = "SECRET";
         let obf = obfuscate_uppercase_word(word);
         assert_eq!(obf.len(), word.len());
-        assert!(is_uppercase_word(Some(&obf)).is_some());
+        assert!(try_uppercase_word(&obf).is_some());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@ use sha3::{Digest, Sha3_256};
 use std::io::{self, Write};
 
 mod classifiers;
-use classifiers::{is_uppercase_word, obfuscate_uppercase_word};
+use classifiers::{obfuscate_uppercase_word, try_alpha_word, try_uppercase_word};
 
 const SYLLABLES: &[&str] = &[
     "a", "e", "i", "o", "u", "y", "ab", "ac", "ad", "af", "ag", "ah", "ak", "al", "am", "an", "ap",
@@ -25,9 +25,6 @@ const SYLLABLES: &[&str] = &[
     "amb", "amm", "amp", "ams", "anb", "anc", "and", "ang", "ank", "ann",
 ];
 
-fn is_alpha_word(s: &str) -> bool {
-    !s.is_empty() && s.chars().all(|c| c.is_ascii_lowercase())
-}
 
 fn hash_word_to_syllables(word: &str) -> String {
     let mut hasher = Sha3_256::new();
@@ -60,9 +57,9 @@ fn hash_word_to_syllables(word: &str) -> String {
 fn hash_strings(value: &mut Value) {
     match value {
         Value::String(s) => {
-            if is_alpha_word(s) {
+            if try_alpha_word(s).is_some() {
                 *s = hash_word_to_syllables(s);
-            } else if is_uppercase_word(Some(s)).is_some() {
+            } else if try_uppercase_word(s).is_some() {
                 *s = obfuscate_uppercase_word(s);
             } else {
                 let mut hasher = Sha3_256::new();
@@ -165,19 +162,19 @@ mod tests {
     #[test]
     fn test_word_obfuscation() {
         let word = "secret";
-        assert!(is_alpha_word(word));
+        assert!(try_alpha_word(word).is_some());
         let obf = hash_word_to_syllables(word);
         assert_eq!(obf.len(), word.len());
-        assert!(is_alpha_word(&obf));
+        assert!(try_alpha_word(&obf).is_some());
     }
 
     #[test]
-    fn test_is_alpha_word_cases() {
-        assert!(!is_alpha_word("Word"));
-        assert!(is_alpha_word("word"));
-        assert!(!is_alpha_word("wo_rd"));
-        assert!(!is_alpha_word("wo-rd"));
-        assert!(!is_alpha_word("WORD"));
+    fn test_try_alpha_word_cases() {
+        assert!(try_alpha_word("Word").is_none());
+        assert!(try_alpha_word("word").is_some());
+        assert!(try_alpha_word("wo_rd").is_none());
+        assert!(try_alpha_word("wo-rd").is_none());
+        assert!(try_alpha_word("WORD").is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add new `try_alpha_word` classifier for lowercase detection
- move classifier logic into `classifiers` module
- update hashing logic and tests to use the new API
- add unit tests for `try_alpha_word`

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_687b3a8061bc8330bdb04c9c3b473f1b