### PR TITLE
Refactor classifiers to boolean is_* API

### DIFF
--- a/src/classifiers.rs
+++ b/src/classifiers.rs
@@ -3,32 +3,19 @@ use sha3::{Digest, Sha3_256};
 /// Detects whether the provided string is composed entirely of ASCII lowercase
 /// letters.
 ///
-/// This follows the repository's classifier conventions by using the `try_`
-/// prefix and returning an `Option` containing the original string on success.
-pub fn try_alpha_word(input: &str) -> Option<&str> {
-    if !input.is_empty() && input.chars().all(|c| c.is_ascii_lowercase()) {
-        Some(input)
-    } else {
-        None
-    }
+pub fn is_alpha_word(input: &str) -> bool {
+    !input.is_empty() && input.chars().all(|c| c.is_ascii_lowercase())
 }
 
 /// Detects whether the provided string is composed entirely of ASCII uppercase
 /// letters.
 ///
-/// The function follows the repository's classifier conventions by using the
-/// `try_` prefix and returning an `Option` containing the original string on
-/// success.
-pub fn try_uppercase_word(input: &str) -> Option<&str> {
-    if !input.is_empty() && input.chars().all(|c| c.is_ascii_uppercase()) {
-        Some(input)
-    } else {
-        None
-    }
+pub fn is_uppercase_word(input: &str) -> bool {
+    !input.is_empty() && input.chars().all(|c| c.is_ascii_uppercase())
 }
 
 /// Obfuscate an uppercase word into another deterministic uppercase word of the
-/// same length. The output will also be recognised by `try_uppercase_word`.
+/// same length. The output will also be recognised by `is_uppercase_word`.
 pub fn obfuscate_uppercase_word(word: &str) -> String {
     let mut hasher = Sha3_256::new();
     hasher.update(word.as_bytes());
@@ -51,21 +38,21 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_try_alpha_word_examples() {
-        assert!(try_alpha_word("lowercase").is_some());
-        assert!(try_alpha_word("lower_case").is_none());
-        assert!(try_alpha_word("Lowercase").is_none());
-        assert!(try_alpha_word("lower-case").is_none());
-        assert!(try_alpha_word("LOWERCASE").is_none());
+    fn test_is_alpha_word_examples() {
+        assert!(is_alpha_word("lowercase"));
+        assert!(!is_alpha_word("lower_case"));
+        assert!(!is_alpha_word("Lowercase"));
+        assert!(!is_alpha_word("lower-case"));
+        assert!(!is_alpha_word("LOWERCASE"));
     }
 
     #[test]
-    fn test_try_uppercase_word_examples() {
-        assert!(try_uppercase_word("UPPERCASE").is_some());
-        assert!(try_uppercase_word("UPPER_CASE").is_none());
-        assert!(try_uppercase_word("UPPER CASE").is_none());
-        assert!(try_uppercase_word("UPPER-CASE").is_none());
-        assert!(try_uppercase_word("UPPERCASe").is_none());
+    fn test_is_uppercase_word_examples() {
+        assert!(is_uppercase_word("UPPERCASE"));
+        assert!(!is_uppercase_word("UPPER_CASE"));
+        assert!(!is_uppercase_word("UPPER CASE"));
+        assert!(!is_uppercase_word("UPPER-CASE"));
+        assert!(!is_uppercase_word("UPPERCASe"));
     }
 
     #[test]
@@ -73,6 +60,6 @@ mod tests {
         let word = "SECRET";
         let obf = obfuscate_uppercase_word(word);
         assert_eq!(obf.len(), word.len());
-        assert!(try_uppercase_word(&obf).is_some());
+        assert!(is_uppercase_word(&obf));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@ use sha3::{Digest, Sha3_256};
 use std::io::{self, Write};
 
 mod classifiers;
-use classifiers::{obfuscate_uppercase_word, try_alpha_word, try_uppercase_word};
+use classifiers::{obfuscate_uppercase_word, is_alpha_word, is_uppercase_word};
 
 const SYLLABLES: &[&str] = &[
     "a", "e", "i", "o", "u", "y", "ab", "ac", "ad", "af", "ag", "ah", "ak", "al", "am", "an", "ap",
@@ -57,9 +57,9 @@ fn hash_word_to_syllables(word: &str) -> String {
 fn hash_strings(value: &mut Value) {
     match value {
         Value::String(s) => {
-            if try_alpha_word(s).is_some() {
+            if is_alpha_word(s) {
                 *s = hash_word_to_syllables(s);
-            } else if try_uppercase_word(s).is_some() {
+            } else if is_uppercase_word(s) {
                 *s = obfuscate_uppercase_word(s);
             } else {
                 let mut hasher = Sha3_256::new();
@@ -162,19 +162,19 @@ mod tests {
     #[test]
     fn test_word_obfuscation() {
         let word = "secret";
-        assert!(try_alpha_word(word).is_some());
+        assert!(is_alpha_word(word));
         let obf = hash_word_to_syllables(word);
         assert_eq!(obf.len(), word.len());
-        assert!(try_alpha_word(&obf).is_some());
+        assert!(is_alpha_word(&obf));
     }
 
     #[test]
-    fn test_try_alpha_word_cases() {
-        assert!(try_alpha_word("Word").is_none());
-        assert!(try_alpha_word("word").is_some());
-        assert!(try_alpha_word("wo_rd").is_none());
-        assert!(try_alpha_word("wo-rd").is_none());
-        assert!(try_alpha_word("WORD").is_none());
+    fn test_is_alpha_word_cases() {
+        assert!(!is_alpha_word("Word"));
+        assert!(is_alpha_word("word"));
+        assert!(!is_alpha_word("wo_rd"));
+        assert!(!is_alpha_word("wo-rd"));
+        assert!(!is_alpha_word("WORD"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- rename `try_alpha_word` and `try_uppercase_word` to `is_alpha_word` and `is_uppercase_word`
- update documentation and unit tests for the new boolean API
- update all call sites in `main.rs`
- strip policy references from classifier docstrings

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_687b3ce39b0c83309599b48adaa81473