### PR TITLE
Use syllable table for uppercase obfuscation

### DIFF
--- a/src/classifiers.rs
+++ b/src/classifiers.rs
@@ -5,20 +5,21 @@ pub const SYLLABLES: &[&str] = &[
     "a", "e", "i", "o", "u", "y", "ab", "ac", "ad", "af", "ag", "ah", "ak", "al", "am", "an", "ap",
     "aq", "ar", "as", "at", "av", "aw", "ax", "az", "ba", "be", "bi", "bo", "bu", "by", "ca", "ce",
     "co", "cu", "da", "de", "di", "do", "du", "dy", "eb", "ec", "ed", "ef", "eg", "eh", "ek", "el",
-    "em", "en", "ep", "eq", "er", "es", "et", "ev", "ew", "ex", "ez", "fa", "fe", "fi", "fo", "fu", "ga",
-    "ge", "gi", "go", "gu", "ha", "he", "hi", "ho", "hu", "ib", "ic", "id", "if", "ig", "ih", "ik", "il",
-    "im", "in", "ip", "iq", "ir", "is", "it", "iv", "ix", "iz", "ja", "je", "jo", "ju", "ka", "ke", "ko", "la",
-    "le", "li", "lo", "lu", "ly", "ma", "me", "mi", "mo", "my", "na", "ne", "no", "ob", "oc", "od", "of", "og",
-    "oh", "ok", "ol", "om", "on", "op", "oq", "or", "os", "ot", "ov", "ow", "ox", "oz", "pa", "pe", "pi", "po",
-    "pu", "qu", "ra", "re", "ri", "ro", "ru", "sa", "se", "si", "so", "su", "ta", "te", "ti", "to", "tu", "ub", "uc",
-    "ud", "uf", "ug", "uh", "uk", "ul", "um", "un", "up", "uq", "ur", "us", "ut", "uv", "uw", "ux", "uz", "va", "ve",
-    "vi", "vo", "wa", "we", "wi", "wo", "xi", "yb", "yc", "yd", "yf", "yg", "yh", "yl", "ym", "yn", "yr", "ys", "yt",
-    "yw", "yx", "yz", "ze", "zo", "abh", "abl", "abr", "abs", "acc", "ach", "ack", "acl", "acq", "acr", "act", "add",
-    "adf", "adh", "adj", "adm", "adr", "ads", "adt", "adv", "aff", "afr", "aft", "agg", "agm", "agn", "agr", "ags",
-    "ahs", "akf", "akn", "aks", "alb", "alc", "ald", "alf", "alg", "alh", "alk", "all", "alm", "alp", "alq", "alr",
-    "als", "alt", "alw", "amb", "amm", "amp", "ams", "anb", "anc", "and", "ang", "ank", "ann",
+    "em", "en", "ep", "eq", "er", "es", "et", "ev", "ew", "ex", "ez", "fa", "fe", "fi", "fo", "fu",
+    "ga", "ge", "gi", "go", "gu", "ha", "he", "hi", "ho", "hu", "ib", "ic", "id", "if", "ig", "ih",
+    "ik", "il", "im", "in", "ip", "iq", "ir", "is", "it", "iv", "ix", "iz", "ja", "je", "jo", "ju",
+    "ka", "ke", "ko", "la", "le", "li", "lo", "lu", "ly", "ma", "me", "mi", "mo", "my", "na", "ne",
+    "no", "ob", "oc", "od", "of", "og", "oh", "ok", "ol", "om", "on", "op", "oq", "or", "os", "ot",
+    "ov", "ow", "ox", "oz", "pa", "pe", "pi", "po", "pu", "qu", "ra", "re", "ri", "ro", "ru", "sa",
+    "se", "si", "so", "su", "ta", "te", "ti", "to", "tu", "ub", "uc", "ud", "uf", "ug", "uh", "uk",
+    "ul", "um", "un", "up", "uq", "ur", "us", "ut", "uv", "uw", "ux", "uz", "va", "ve", "vi", "vo",
+    "wa", "we", "wi", "wo", "xi", "yb", "yc", "yd", "yf", "yg", "yh", "yl", "ym", "yn", "yr", "ys",
+    "yt", "yw", "yx", "yz", "ze", "zo", "abh", "abl", "abr", "abs", "acc", "ach", "ack", "acl",
+    "acq", "acr", "act", "add", "adf", "adh", "adj", "adm", "adr", "ads", "adt", "adv", "aff",
+    "afr", "aft", "agg", "agm", "agn", "agr", "ags", "ahs", "akf", "akn", "aks", "alb", "alc",
+    "ald", "alf", "alg", "alh", "alk", "all", "alm", "alp", "alq", "alr", "als", "alt", "alw",
+    "amb", "amm", "amp", "ams", "anb", "anc", "and", "ang", "ank", "ann",
 ];
-
 
 /// Detects whether the provided string is composed entirely of ASCII lowercase
 /// letters.
@@ -66,32 +67,11 @@ pub fn hash_word_to_syllables(word: &str) -> String {
 /// Obfuscate an uppercase word into another deterministic uppercase word of the
 /// same length. The output will also be recognised by `is_uppercase_word`.
 pub fn obfuscate_uppercase_word(word: &str) -> String {
-    let mut hasher = Sha3_256::new();
-    hasher.update(word.as_bytes());
-    let hash = hasher.finalize();
-    let mut out = String::new();
-
-    for &b in hash.as_slice() {
-        let c = ((b % 26) as u8 + b'A') as char;
-        out.push(c);
-    }
-
-    if out.len() >= word.len() {
-        out.truncate(word.len());
-    } else {
-        while out.len() < word.len() {
-            for &b in hash.as_slice() {
-                let c = ((b % 26) as u8 + b'A') as char;
-                out.push(c);
-                if out.len() >= word.len() {
-                    break;
-                }
-            }
-        }
-        out.truncate(word.len());
-    }
-
-    out
+    // Reuse the lowercase syllable obfuscation and convert the result to
+    // uppercase. This guarantees determinism while sharing the syllable table
+    // logic with `hash_word_to_syllables`.
+    let hashed = hash_word_to_syllables(&word.to_lowercase());
+    hashed.to_ascii_uppercase()
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,11 +4,10 @@ use std::io::{self, Write};
 
 mod classifiers;
 use classifiers::{
-    hash_word_to_syllables, obfuscate_uppercase_word, is_alpha_word, is_uppercase_word,
+    hash_word_to_syllables, is_alpha_word, is_uppercase_word, obfuscate_uppercase_word,
 };
 
 fn hash_strings(value: &mut Value) {
-
     match value {
         Value::String(s) => {
             if is_alpha_word(s) {
@@ -110,7 +109,7 @@ mod tests {
         assert_eq!(value["b"][0], json!("o"));
         assert_eq!(value["b"][1], json!(1));
         assert_eq!(value["c"]["d"], json!("u"));
-        assert_eq!(value["u"], json!("XQEAM"));
+        assert_eq!(value["u"], json!("AHSON"));
     }
 
     #[test]
@@ -135,7 +134,7 @@ mod tests {
         const EXPECTED_HASHES: &str = r#"[
   {
     "additional_information": "4e9be9f98ffaf00dfa6849b118ec0eebaeb9d1fedf49794efc978549d692a644",
-    "category": "TWICT",
+    "category": "UMACL",
     "created_at": "cf8cbca8ef96e021217ba62b3f9bc79b3358df6ffabf3036555eb093b6a03900",
     "id": "88cf7ddaff83bfd6f3c9b2f8dfd90987628b01a689b04b0d6f4d6bc05e77c8db",
     "last_edited_by": "972e64ff2f45cb894fd548bbdd0f7d430ba23400502ac9c650d4aa053360ca37",


### PR DESCRIPTION
## Summary
- refactor `obfuscate_uppercase_word` to reuse `hash_word_to_syllables`
- update tests for new uppercase behaviour

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_687b4ef59334833083f78c502a314266