### PR TITLE
Add capitalized word classifier

### DIFF
--- a/src/classifiers.rs
+++ b/src/classifiers.rs
@@ -35,6 +35,22 @@ pub fn is_uppercase_word(input: &str) -> bool {
     !input.is_empty() && input.chars().all(|c| c.is_ascii_uppercase())
 }
 
+/// Detects whether the provided string is a capitalized word where the first
+/// character is uppercase ASCII and the remaining characters are lowercase
+/// ASCII.
+pub fn is_capitalized_word(input: &str) -> bool {
+    if input.is_empty() {
+        return false;
+    }
+    let mut chars = input.chars();
+    match chars.next() {
+        Some(first) if first.is_ascii_uppercase() => {
+            chars.all(|c| c.is_ascii_lowercase())
+        }
+        _ => false,
+    }
+}
+
 /// Deterministically obfuscate a lowercase word into another lowercase word of
 /// the same length using a syllable table.
 pub fn hash_word_to_syllables(word: &str) -> String {
@@ -74,6 +90,22 @@ pub fn obfuscate_uppercase_word(word: &str) -> String {
     hashed.to_ascii_uppercase()
 }
 
+/// Obfuscate a capitalized word (first letter uppercase, rest lowercase) into
+/// another deterministic capitalized word of the same length. The output will
+/// also be recognised by `is_capitalized_word`.
+pub fn obfuscate_capitalized_word(word: &str) -> String {
+    let hashed = hash_word_to_syllables(&word.to_lowercase());
+    if hashed.is_empty() {
+        return hashed;
+    }
+    let mut chars = hashed.chars();
+    let first = chars.next().unwrap().to_ascii_uppercase();
+    let mut out = String::new();
+    out.push(first);
+    out.extend(chars);
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -97,11 +129,30 @@ mod tests {
     }
 
     #[test]
+    fn test_is_capitalized_word_examples() {
+        assert!(is_capitalized_word("Test"));
+        assert!(!is_capitalized_word("test"));
+        assert!(!is_capitalized_word("tEST"));
+        assert!(!is_capitalized_word("Test Test"));
+        assert!(!is_capitalized_word("Test-udo"));
+        assert!(!is_capitalized_word("Test test"));
+        assert!(!is_capitalized_word("TEst"));
+    }
+
+    #[test]
     fn test_obfuscate_uppercase_word_preserves_class() {
         let word = "SECRET";
         let obf = obfuscate_uppercase_word(word);
         assert_eq!(obf.len(), word.len());
         assert!(is_uppercase_word(&obf));
+    }
+
+    #[test]
+    fn test_obfuscate_capitalized_word_preserves_class() {
+        let word = "Secret";
+        let obf = obfuscate_capitalized_word(word);
+        assert_eq!(obf.len(), word.len());
+        assert!(is_capitalized_word(&obf));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,8 @@ use std::io::{self, Write};
 
 mod classifiers;
 use classifiers::{
-    hash_word_to_syllables, is_alpha_word, is_uppercase_word, obfuscate_uppercase_word,
+    hash_word_to_syllables, is_alpha_word, is_uppercase_word, is_capitalized_word,
+    obfuscate_uppercase_word, obfuscate_capitalized_word,
 };
 
 fn hash_strings(value: &mut Value) {
@@ -14,6 +15,8 @@ fn hash_strings(value: &mut Value) {
                 *s = hash_word_to_syllables(s);
             } else if is_uppercase_word(s) {
                 *s = obfuscate_uppercase_word(s);
+            } else if is_capitalized_word(s) {
+                *s = obfuscate_capitalized_word(s);
             } else {
                 let mut hasher = Sha3_256::new();
                 hasher.update(s.as_bytes());
@@ -100,6 +103,7 @@ mod tests {
             "a": "test",
             "b": ["x", 1],
             "c": {"d": "y"},
+            "cap": "Word",
             "u": "UPPER"
         });
 
@@ -109,6 +113,7 @@ mod tests {
         assert_eq!(value["b"][0], json!("o"));
         assert_eq!(value["b"][1], json!(1));
         assert_eq!(value["c"]["d"], json!("u"));
+        assert_eq!(value["cap"], json!("Eqon"));
         assert_eq!(value["u"], json!("AHSON"));
     }
 
@@ -139,7 +144,7 @@ mod tests {
     "id": "88cf7ddaff83bfd6f3c9b2f8dfd90987628b01a689b04b0d6f4d6bc05e77c8db",
     "last_edited_by": "972e64ff2f45cb894fd548bbdd0f7d430ba23400502ac9c650d4aa053360ca37",
     "lower case word": "epagrfiovusso",
-    "title": "884e4e4f1742800cbbbb1ffec554ebcd61e8b94cec27ca11efc017c9d582692e",
+    "title": "Ylads",
     "updated_at": "cf8cbca8ef96e021217ba62b3f9bc79b3358df6ffabf3036555eb093b6a03900",
     "urls": [
       {
@@ -150,7 +155,7 @@ mod tests {
     ],
     "vault": {
       "id": "c3427b6423f76857e8ae40651586be4c8bda92ba9c10c201755cb474ea3236d0",
-      "name": "2a82dce0734a47938504d6b913fa6c0f05ccefdcc30c96e429f391178770020b"
+      "name": "Aknbedyip"
     },
     "version": 1
   }


### PR DESCRIPTION
## Summary
- detect capitalized words and provide obfuscation
- support capitalized word classifier in the main hashing logic
- test capitalized word detection and obfuscation
- update expected sample output for new obfuscation

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_687b50ea767883308d0ec921472beab9