### PR TITLE
Add well-known inputs dataset and integrate in tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,4 +6,18 @@ This repository may include multiple string classifier functions. When adding a 
 2. **Write a unit test.** Each classifier requires a unit test showing that a sample string matches (or does not match) the classifier, the test should check that the obfuscated text also matches the same classifier. Tests can live in the same file under a `#[cfg(test)]` module or in another test module. 
 3. **Run tests.** After implementing or modifying classifiers, run `cargo test` to ensure all tests pass.
 
+### Well-known Examples
+
+Maintain a list of sample inputs for every classifier under `tests/well_known_inputs.rs`.
+Each entry should pair an input string with the classifiers that detect it.
+When adding or modifying a classifier, update this list and use it in unit tests
+to verify the expected results.
+
+### Obfuscation Rules
+
+The default obfuscation strategy is to hash the entire input string without any
+modification. The resulting hash should then be converted into a human‑readable
+form, which is used to reconstruct the obfuscated text. All classifiers should
+follow this rule when providing obfuscation functions.
+
 These guidelines apply to all future classifier-related changes.

--- a/tests/well_known_inputs.rs
+++ b/tests/well_known_inputs.rs
@@ -1,0 +1,27 @@
+pub struct Example {
+    pub input: &'static str,
+    pub detectors: &'static [&'static str],
+}
+
+pub const WELL_KNOWN_INPUTS: &[Example] = &[
+    Example {
+        input: "lowercase",
+        detectors: &["alpha_word"],
+    },
+    Example {
+        input: "UPPERCASE",
+        detectors: &["uppercase_word"],
+    },
+    Example {
+        input: "Capitalized",
+        detectors: &["capitalized_word"],
+    },
+    Example {
+        input: "snake_case_word",
+        detectors: &["snake_case_word"],
+    },
+    Example {
+        input: "A Title Case Sentence",
+        detectors: &["title_case_sentence"],
+    },
+];


### PR DESCRIPTION
## Summary
- maintain a shared list of well-known classifier examples
- include those examples in unit tests for detection and obfuscation
- update title-case classifier tests accordingly
- fix title-case detection and dataset naming

## Testing
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_68806156181c83309a08ec4eb1ee0974