### PR TITLE
Add lowercase Base32 classifier

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,6 +102,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -231,6 +237,7 @@ name = "pipefog"
 version = "0.1.0"
 dependencies = [
  "chrono",
+ "data-encoding",
  "hex",
  "lazy_static",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ lazy_static = "1.*"
 hex = "0.4"
 chrono = "0.4"
 rand = "0.8"
+data-encoding = "2.*"
 
 
 [[bin]]

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,8 +4,9 @@ use std::io::{self, Write};
 
 mod classifiers;
 use classifiers::{
-    hash_word_to_syllables, is_alpha_word, is_capitalized_word, is_iso8601_z_datetime,
-    is_snake_case_word, is_uppercase_word, obfuscate_capitalized_word,
+    hash_word_to_syllables, is_alpha_word, is_base32_lowercase, is_capitalized_word,
+    is_iso8601_z_datetime, is_snake_case_word, is_uppercase_word,
+    obfuscate_base32_lowercase, obfuscate_capitalized_word,
     obfuscate_iso8601_z_datetime, obfuscate_snake_case_word, obfuscate_uppercase_word,
 };
 
@@ -22,6 +23,8 @@ fn hash_strings(value: &mut Value) {
                 *s = obfuscate_capitalized_word(s);
             } else if is_iso8601_z_datetime(s) {
                 *s = obfuscate_iso8601_z_datetime(s);
+            } else if is_base32_lowercase(s) {
+                *s = obfuscate_base32_lowercase(s);
             } else {
                 let mut hasher = Sha3_256::new();
                 hasher.update(s.as_bytes());
@@ -148,7 +151,7 @@ mod tests {
     "additional_information": "4e9be9f98ffaf00dfa6849b118ec0eebaeb9d1fedf49794efc978549d692a644",
     "category": "MANNO",
     "created_at": "2000-01-01T00:00:00Z",
-    "id": "88cf7ddaff83bfd6f3c9b2f8dfd90987628b01a689b04b0d6f4d6bc05e77c8db",
+    "id": "rdhx3wx7qo75n46jwl4n7wijq5",
     "last_edited_by": "972e64ff2f45cb894fd548bbdd0f7d430ba23400502ac9c650d4aa053360ca37",
     "lower case word": "vericthesneup",
     "title": "Butfa",
@@ -161,7 +164,7 @@ mod tests {
       }
     ],
     "vault": {
-      "id": "c3427b6423f76857e8ae40651586be4c8bda92ba9c10c201755cb474ea3236d0",
+      "id": "ynbhwzbd65ufp2foibsrlbv6js",
       "name": "Hedencont"
     },
     "version": 1

--- a/tests/well_known_inputs.rs
+++ b/tests/well_known_inputs.rs
@@ -28,4 +28,8 @@ pub const WELL_KNOWN_INPUTS: &[Example] = &[
         input: "2022-05-16T22:39:20Z",
         detectors: &["iso8601_z_datetime"],
     },
+    Example {
+        input: "mfrggzdfmztwq2lknnwg23tp",
+        detectors: &["base32_lowercase"],
+    },
 ];


### PR DESCRIPTION
## Summary
- detect lowercase Base32 strings longer than 16 characters
- obfuscate lowercase Base32 strings deterministically while preserving length
- expand well-known inputs and hashing logic to handle lowercase Base32

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6895b82d0014833094e1d4f1534a4a91