### PR TITLE
docs: add architecture diagram to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,13 +35,13 @@ remains a valid ISO 8601 `Z` datetime while preserving relative differences.
 This project documents its system architecture using Mermaid diagrams, which GitHub renders natively.
 
 ```mermaid
-flowchart TD
-    A[Input stream (JSON/YAML)] --> B[pipefog CLI]
-    B --> C[Mode]
-    C -->|default| D[Parse & obfuscate strings]
-    D --> E[Output stream]
-    C -->|humanise| F[Convert bytes to syllables]
-    C -->|syllable-frequency| G[Report syllable stats]
+graph TD
+    A["Input stream (JSON/YAML)"] --> B["pipefog CLI"]
+    B --> C["Mode"]
+    C -->|default| D["Parse & obfuscate strings"]
+    D --> E["Output stream"]
+    C -->|humanise| F["Convert bytes to syllables"]
+    C -->|syllable-frequency| G["Report syllable stats"]
 ```
 
 Planned features:

--- a/README.md
+++ b/README.md
@@ -30,6 +30,20 @@ cat secrets.json | jq . | pipefog | jq .
 original baseline. Every subsequent datetime is shifted relative to these baselines so the output
 remains a valid ISO 8601 `Z` datetime while preserving relative differences.
 
+## 🏗️ Architecture
+
+This project documents its system architecture using Mermaid diagrams, which GitHub renders natively.
+
+```mermaid
+flowchart TD
+    A[Input stream (JSON/YAML)] --> B[pipefog CLI]
+    B --> C{Mode}
+    C -->|default| D[Parse & obfuscate strings]
+    D --> E[Output stream]
+    C -->|humanise| F[Convert bytes to syllables]
+    C -->|syllable-frequency| G[Report syllable stats]
+```
+
 Planned features:
 
 - ✅ Streaming-safe – Process large files through stdin/stdout with minimal memory usage.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ This project documents its system architecture using Mermaid diagrams, which Git
 ```mermaid
 flowchart TD
     A[Input stream (JSON/YAML)] --> B[pipefog CLI]
-    B --> C{Mode}
+    B --> C[Mode]
     C -->|default| D[Parse & obfuscate strings]
     D --> E[Output stream]
     C -->|humanise| F[Convert bytes to syllables]


### PR DESCRIPTION
## Summary
- note use of Mermaid diagrams in README
- add high-level architecture diagram illustrating CLI modes

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68a94bd2ee448330afe01279fd58b1cd